### PR TITLE
[Matrix|N*] fix track length show, copyright year increase and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ------------------
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audiodecoder.asap.svg?branch=Matrix)](https://travis-ci.org/xbmc/audiodecoder.asap/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.asap?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=4&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.asap/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.asap/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.asap?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-asap?branch=Matrix) -->

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: audiodecoder.asap
 Source: https://github.com/xbmc/audiodecoder.asap
 
 Files: *
-Copyright: 2005-2020 Team Kodi
+Copyright: 2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/ASAPCodec.cpp
+++ b/src/ASAPCodec.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/ASAPCodec.cpp
+++ b/src/ASAPCodec.cpp
@@ -104,6 +104,7 @@ bool CASAPCodec::ReadTag(const std::string& filename, kodi::addon::AudioDecoderI
   {
     size_t iStart = toLoad.rfind('-') + 1;
     track = atoi(toLoad.substr(iStart, toLoad.size() - iStart - 11).c_str());
+
     //  The directory we are in, is the file
     //  that contains the bitstream to play,
     //  so extract it
@@ -136,7 +137,8 @@ bool CASAPCodec::ReadTag(const std::string& filename, kodi::addon::AudioDecoderI
   const ASAPInfo* info = ASAP_GetInfo(asap);
   tag.SetArtist(ASAPInfo_GetAuthor(info));
   tag.SetTitle(ASAPInfo_GetTitleOrFilename(info));
-  tag.SetDuration(ASAPInfo_GetDuration(info, track) / 1000);
+  // Kodi gives them beginning with 1, ASAP there need to start with 0, so we reduce it by one.
+  tag.SetDuration(ASAPInfo_GetDuration(info, track > 0 ? track - 1 : 0) / 1000);
   if (ASAPInfo_GetYear(info) > 0)
     tag.SetReleaseDate(std::to_string(ASAPInfo_GetYear(info)));
   tag.SetChannels(ASAPInfo_GetChannels(info));

--- a/src/ASAPCodec.h
+++ b/src/ASAPCodec.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.


### PR DESCRIPTION
This update:
- fix shown track length on asap files where contains multiple tracks (see pictures below)
- set copyright year to 2021
- remove the status badge about Travis CI
  - The build script stais currently in, maybe usable for something else or they allow again a bit more by travis.com

Before fix:
![Bildschirmfoto vom 2021-04-11 16-30-42](https://user-images.githubusercontent.com/6879739/114308193-48871c80-9ae3-11eb-9f9c-05099ff12afe.png)

After fix:
![Bildschirmfoto vom 2021-04-11 16-28-02](https://user-images.githubusercontent.com/6879739/114308155-242b4000-9ae3-11eb-9e29-51f135365182.png)

Performed compile and run test on Linux with C++14, C++17 and C++20.
Runtime tests was OK.