### PR TITLE
[Matrix] final Matrix change to correct test builds and take as Version 19.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
       osx_image: xcode10.2
 
 before_install:
-  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/ppa; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
 
@@ -45,12 +45,12 @@ before_install:
 #
 before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then cd $TRAVIS_BUILD_DIR/..; fi
-  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir build && cd build; fi
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
-  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/Matrix/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
 script: 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ASAP (Another Slight Atari Player) plays on Kodi and converts 8-bit Atari music 
 ## Build instructions
 
 When building the addon you have to use the correct branch depending on which version of Kodi you're building against. 
-If you want to build the addon to be compatible with the latest kodi `master` commit, you need to checkout the branch with the current kodi codename.
+If you want to build the addon to be compatible with the latest kodi `Matrix` commit, you need to checkout the branch with the current kodi codename.
 Also make sure you follow this README from the branch in question.
 
 ### Linux
@@ -26,7 +26,7 @@ Also make sure you follow this README from the branch in question.
 The following instructions assume you will have built Kodi already in the `kodi-build` directory 
 suggested by the README.
 
-1. `git clone --branch master https://github.com/xbmc/xbmc.git`
+1. `git clone --branch Matrix https://github.com/xbmc/xbmc.git`
 2. `git clone https://github.com/xbmc/audiodecoder.asap.git`
 3. `cd audiodecoder.asap && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=audiodecoder.asap -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ environment:
 
 build_script:
   - cd ..
-  - git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
+  - git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git
   - cd %app_id%
   - mkdir build
   - cd build

--- a/audiodecoder.asap/addon.xml.in
+++ b/audiodecoder.asap/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.asap"
-  version="3.0.1"
+  version="19.0.0"
   name="ASAP Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
 
     - script: |
         cd ..
-        git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git kodi
+        git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git kodi
         cd $(Build.SourcesDirectory)
         mkdir build
         cd build


### PR DESCRIPTION
This change the builds to final released Kodi Matrix.

Further is the version to 19.0.0 increased to have equal to Kodi and to see on which Version this addon works.